### PR TITLE
fix css error

### DIFF
--- a/config/webpack.plugins.js
+++ b/config/webpack.plugins.js
@@ -8,8 +8,8 @@ const BundleAnalyzerPlugin =
 module.exports = [
     new ForkTsCheckerWebpackPlugin(),
     new MiniCssExtractPlugin({
-        filename: '[name].[chunkhash].css',
-        chunkFilename: '[name].[chunkhash].chunk.css',
+        filename: 'static/chunks/[name].[chunkhash].css',
+        chunkFilename: 'static/chunks/[name].[chunkhash].chunk.css',
     }),
     new BundleAnalyzerPlugin({
         analyzerMode: 'static',

--- a/next.config.js
+++ b/next.config.js
@@ -38,4 +38,4 @@ const nextConfig = {
     },
 };
 
-module.exports = { output: 'standalone', ...nextConfig };
+module.exports = { ...nextConfig };


### PR DESCRIPTION
## - PR Type

-   [x] Bugfix
-   [ ] Feature
-   [ ] Code style update
-   [ ] Refactoring
-   [x] Build related changes
-   [ ] CI related changes
-   [ ] Documentation content changes
-   [ ] Others... Please describe:
        <br>

## - Motivation

- #16 

<br>

## - Key Changes

- webpack 설정의 `MiniCssExtractPlugin` 의 extract 경로가 잘못 지정되어 있어 수정했습니다.

<br>

## - Screenshots (optional)
